### PR TITLE
fix(guards): add directory decomposition self-review to blueprint

### DIFF
--- a/blackbox/role=behaver/__snapshots__/skill.init.behavior.guards.acceptance.test.ts.snap
+++ b/blackbox/role=behaver/__snapshots__/skill.init.behavior.guards.acceptance.test.ts.snap
@@ -246,7 +246,7 @@ exports[`skill.init.behavior.guards.journey given: [case1] full behavior route w
 
 🌕 lets reflect
    │
-   ├─ review.self 1/17
+   ├─ review.self 1/18
    │  ├─ slug = has-research-traceability
    │  ├─ question all, especially yourself
    │  └─ see the guide below
@@ -362,11 +362,12 @@ exports[`skill.init.behavior.guards.journey given: [case1] full behavior route w
    ├─ reason = wait for human approval
    └─ guard
       ├─ artifacts
+      │   ├─ 3.3.1.blueprint.product.yield.md
       │   └─ 3.3.1.blueprint.product.yield.md
       ├─ reviews
       │   └─ r1: npx rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '$route/3.3.blueprint.*.md' --join intersect --output '$route/.reviews/$stone.peer-review.failhides.md' --mode hard
       │       ├─ finished [time] ✓
-      │       └─ review: .route/3.3.1.blueprint.product.guard.review.i1.b32e81c0243f833ead9d83a736ce48ef4111c16f834a1ccbd5e7e66dfc4399b9.r1.md
+      │       └─ review: .route/3.3.1.blueprint.product.guard.review.i1.39b43fb8815ed028463dacbb96ae2eb8e5c63aa730f616bbc1cb1aa06d7a6658.r1.md
       └─ judges
           ├─ j1: npx rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3
           │   └─ finished [time] ✓
@@ -420,6 +421,7 @@ exports[`skill.init.behavior.guards.journey given: [case1] full behavior route w
    ├─ passage = allowed
    ├─ guard
    │  ├─ artifacts
+   │  │   ├─ 3.3.1.blueprint.product.yield.md
    │  │   └─ 3.3.1.blueprint.product.yield.md
    │  ├─ reviews
    │  │   └─ r1: npx rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '$route/3.3.blueprint.*.md' --join intersect --output '$route/.reviews/$stone.peer-review.failhides.md' --mode hard

--- a/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.heavy
+++ b/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.heavy
@@ -288,7 +288,87 @@ reviews:
         1. align with the extant convention
         2. or flag as an open question if the extant convention seems wrong
 
-    # 14. behavior coverage
+    # 14. directory decomposition
+    - slug: has-proper-directory-decomposition
+      say: |
+        review that directories follow the layered decomposition pattern and
+        that subdomains have proper namespace via subdirectories.
+
+        ## layer structure
+
+        the blueprint must organize files into the correct top-level layers:
+
+        ```
+        src/
+          contract/           # public interfaces (cli/, api/, sdk/)
+          access/             # infrastructure (daos/, sdks/, svcs/)
+          domain.objects/     # domain declarations
+          domain.operations/  # domain behavior
+          infra/              # adapters
+        ```
+
+        for each file in the blueprint, ask:
+        - is this file placed in the correct layer?
+        - does a transformer belong in domain.operations/, not contract/?
+        - does a dao belong in access/daos/, not domain.operations/?
+        - does an api endpoint belong in contract/api/, not at src/ root?
+
+        ## subdomain namespace structure
+
+        subdomains must be namespaced via subdirectories, not flat at the root.
+
+        👎 bad — flat structure (no subdomain directories):
+        ```
+        domain.operations/
+          getCustomer.ts
+          setCustomer.ts
+          getInvoice.ts
+          setInvoice.ts
+          computeTotal.ts
+        ```
+
+        👎 bad — subdomains flattened to root:
+        ```
+        domain.operations/
+          customer/
+          phone/           # should be under customer/
+          invoice/
+          lineItem/        # should be under invoice/
+        ```
+
+        👍 good — properly nested by subdomain:
+        ```
+        domain.operations/
+          customer/
+            getCustomer.ts
+            setCustomer.ts
+            phone/
+              getCustomerPhone.ts
+              setCustomerPhone.ts
+          invoice/
+            getInvoice.ts
+            setInvoice.ts
+            lineItem/
+              computeLineItemTotal.ts
+              getLineItems.ts
+        ```
+
+        for each new file in the blueprint, ask:
+        - is this file namespaced under a subdomain directory?
+        - are related operations grouped together?
+        - does the directory structure reflect bounded contexts?
+        - did we dump all files flat at the layer root?
+
+        ## consistency with extant structure
+
+        check how the codebase currently organizes files:
+        - does the blueprint match extant directory patterns?
+        - if extant structure is flat, should we propose refactor or match it?
+        - if extant structure is namespaced, do we follow the same pattern?
+
+        fix all directory placement issues before you continue.
+
+    # 15. behavior coverage
     - slug: has-behavior-declaration-coverage
       say: |
         review for coverage of the behavior declaration.
@@ -305,7 +385,7 @@ reviews:
 
         fix all gaps before you continue.
 
-    # 15. behavior adherance
+    # 16. behavior adherance
     - slug: has-behavior-declaration-adherance
       say: |
         review for adherance to the behavior declaration.
@@ -322,7 +402,7 @@ reviews:
 
         fix all gaps before you continue.
 
-    # 16. standards adherance
+    # 17. standards adherance
     - slug: has-role-standards-adherance
       say: |
         review for adherance to mechanic role standards.
@@ -342,7 +422,7 @@ reviews:
 
         fix all gaps before you continue.
 
-    # 17. standards coverage
+    # 18. standards coverage
     - slug: has-role-standards-coverage
       say: |
         review for coverage of mechanic role standards.

--- a/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.light
+++ b/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.light
@@ -236,7 +236,87 @@ reviews:
         1. align with the extant convention
         2. or flag as an open question if the extant convention seems wrong
 
-    # 10. behavior coverage
+    # 10. directory decomposition
+    - slug: has-proper-directory-decomposition
+      say: |
+        review that directories follow the layered decomposition pattern and
+        that subdomains have proper namespace via subdirectories.
+
+        ## layer structure
+
+        the blueprint must organize files into the correct top-level layers:
+
+        ```
+        src/
+          contract/           # public interfaces (cli/, api/, sdk/)
+          access/             # infrastructure (daos/, sdks/, svcs/)
+          domain.objects/     # domain declarations
+          domain.operations/  # domain behavior
+          infra/              # adapters
+        ```
+
+        for each file in the blueprint, ask:
+        - is this file placed in the correct layer?
+        - does a transformer belong in domain.operations/, not contract/?
+        - does a dao belong in access/daos/, not domain.operations/?
+        - does an api endpoint belong in contract/api/, not at src/ root?
+
+        ## subdomain namespace structure
+
+        subdomains must be namespaced via subdirectories, not flat at the root.
+
+        👎 bad — flat structure (no subdomain directories):
+        ```
+        domain.operations/
+          getCustomer.ts
+          setCustomer.ts
+          getInvoice.ts
+          setInvoice.ts
+          computeTotal.ts
+        ```
+
+        👎 bad — subdomains flattened to root:
+        ```
+        domain.operations/
+          customer/
+          phone/           # should be under customer/
+          invoice/
+          lineItem/        # should be under invoice/
+        ```
+
+        👍 good — properly nested by subdomain:
+        ```
+        domain.operations/
+          customer/
+            getCustomer.ts
+            setCustomer.ts
+            phone/
+              getCustomerPhone.ts
+              setCustomerPhone.ts
+          invoice/
+            getInvoice.ts
+            setInvoice.ts
+            lineItem/
+              computeLineItemTotal.ts
+              getLineItems.ts
+        ```
+
+        for each new file in the blueprint, ask:
+        - is this file namespaced under a subdomain directory?
+        - are related operations grouped together?
+        - does the directory structure reflect bounded contexts?
+        - did we dump all files flat at the layer root?
+
+        ## consistency with extant structure
+
+        check how the codebase currently organizes files:
+        - does the blueprint match extant directory patterns?
+        - if extant structure is flat, should we propose refactor or match it?
+        - if extant structure is namespaced, do we follow the same pattern?
+
+        fix all directory placement issues before you continue.
+
+    # 11. behavior coverage
     - slug: has-behavior-declaration-coverage
       say: |
         review for coverage of the behavior declaration.
@@ -253,7 +333,7 @@ reviews:
 
         fix all gaps before you continue.
 
-    # 11. behavior adherance
+    # 12. behavior adherance
     - slug: has-behavior-declaration-adherance
       say: |
         review for adherance to the behavior declaration.
@@ -270,7 +350,7 @@ reviews:
 
         fix all gaps before you continue.
 
-    # 12. standards adherance
+    # 13. standards adherance
     - slug: has-role-standards-adherance
       say: |
         review for adherance to mechanic role standards.
@@ -290,7 +370,7 @@ reviews:
 
         fix all gaps before you continue.
 
-    # 13. standards coverage
+    # 14. standards coverage
     - slug: has-role-standards-coverage
       say: |
         review for coverage of mechanic role standards.


### PR DESCRIPTION
fix(guards): add directory decomposition self-review to blueprint

- added has-proper-directory-decomposition self-review
- checks layer structure (contract/, access/, domain.*, infra/)
- checks subdomain namespace structure (nested vs flat)
- includes two bad examples and one good example
- light guard now has 14 self-reviews
- heavy guard now has 18 self-reviews

---
🐢🌊 surfed in by seaturtle[bot]