### PR TITLE
fix(templates): prefix peer review roles with behaver

### DIFF
--- a/blackbox/role=behaver/__snapshots__/skill.init.behavior.guards.acceptance.test.ts.snap
+++ b/blackbox/role=behaver/__snapshots__/skill.init.behavior.guards.acceptance.test.ts.snap
@@ -390,16 +390,16 @@ exports[`skill.init.behavior.guards.journey given: [case1] full behavior route w
       │   ├─ r1: npx rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '$route/3.3.blueprint.*.md' --join intersect --output '$route/.reviews/$stone.peer-review.failhides.md' --mode hard
       │   │   ├─ finished [time] ✓
       │   │   └─ review: .route/3.3.1.blueprint.product.guard.review.i1.39b43fb8815ed028463dacbb96ae2eb8e5c63aa730f616bbc1cb1aa06d7a6658.r1.md
-      │   ├─ r2: npx rhachet enroll claude --roles architect,mechanic -p "review the blueprint at $route/$stone.md for architectural gaps and defects. emit BLOCKERS and NITPICKS."
+      │   ├─ r2: npx rhachet enroll claude --roles behaver,architect,mechanic -p "review the blueprint at $route/$stone.md for architectural gaps and defects. emit BLOCKERS and NITPICKS."
       │   │   ├─ finished [time] ✓
       │   │   └─ review: .route/3.3.1.blueprint.product.guard.review.i1.39b43fb8815ed028463dacbb96ae2eb8e5c63aa730f616bbc1cb1aa06d7a6658.r2.md
-      │   ├─ r3: npx rhachet enroll claude --roles architect,mechanic -p "review diff for architectural scope leak, decompose to reuse opportunities, and other arch smells. emit BLOCKERS and NITPICKS."
+      │   ├─ r3: npx rhachet enroll claude --roles behaver,architect,mechanic -p "review diff for architectural scope leak, decompose to reuse opportunities, and other arch smells. emit BLOCKERS and NITPICKS."
       │   │   ├─ finished [time] ✓
       │   │   └─ review: .route/3.3.1.blueprint.product.guard.review.i1.39b43fb8815ed028463dacbb96ae2eb8e5c63aa730f616bbc1cb1aa06d7a6658.r3.md
-      │   ├─ r4: npx rhachet enroll claude --roles ergonomist,mechanic -p "review the blueprint for snapshot coverage on contract endpoints and acceptance test user journey coverage. emit BLOCKERS and NITPICKS."
+      │   ├─ r4: npx rhachet enroll claude --roles behaver,ergonomist,mechanic -p "review the blueprint for snapshot coverage on contract endpoints and acceptance test user journey coverage. emit BLOCKERS and NITPICKS."
       │   │   ├─ finished [time] ✓
       │   │   └─ review: .route/3.3.1.blueprint.product.guard.review.i1.39b43fb8815ed028463dacbb96ae2eb8e5c63aa730f616bbc1cb1aa06d7a6658.r4.md
-      │   └─ r5: npx rhachet enroll claude --roles ergonomist,mechanic -p "review the blueprint for experiential and visual blemishes in snapshotted acceptance test journeys. emit BLOCKERS and NITPICKS."
+      │   └─ r5: npx rhachet enroll claude --roles behaver,ergonomist,mechanic -p "review the blueprint for experiential and visual blemishes in snapshotted acceptance test journeys. emit BLOCKERS and NITPICKS."
       │       ├─ finished [time] ✓
       │       └─ review: .route/3.3.1.blueprint.product.guard.review.i1.39b43fb8815ed028463dacbb96ae2eb8e5c63aa730f616bbc1cb1aa06d7a6658.r5.md
       └─ judges
@@ -464,13 +464,13 @@ exports[`skill.init.behavior.guards.journey given: [case1] full behavior route w
    │  ├─ reviews
    │  │   ├─ r1: npx rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '$route/3.3.blueprint.*.md' --join intersect --output '$route/.reviews/$stone.peer-review.failhides.md' --mode hard
    │  │   │   └─ · cached
-   │  │   ├─ r2: npx rhachet enroll claude --roles architect,mechanic -p "review the blueprint at $route/$stone.md for architectural gaps and defects. emit BLOCKERS and NITPICKS."
+   │  │   ├─ r2: npx rhachet enroll claude --roles behaver,architect,mechanic -p "review the blueprint at $route/$stone.md for architectural gaps and defects. emit BLOCKERS and NITPICKS."
    │  │   │   └─ · cached
-   │  │   ├─ r3: npx rhachet enroll claude --roles architect,mechanic -p "review diff for architectural scope leak, decompose to reuse opportunities, and other arch smells. emit BLOCKERS and NITPICKS."
+   │  │   ├─ r3: npx rhachet enroll claude --roles behaver,architect,mechanic -p "review diff for architectural scope leak, decompose to reuse opportunities, and other arch smells. emit BLOCKERS and NITPICKS."
    │  │   │   └─ · cached
-   │  │   ├─ r4: npx rhachet enroll claude --roles ergonomist,mechanic -p "review the blueprint for snapshot coverage on contract endpoints and acceptance test user journey coverage. emit BLOCKERS and NITPICKS."
+   │  │   ├─ r4: npx rhachet enroll claude --roles behaver,ergonomist,mechanic -p "review the blueprint for snapshot coverage on contract endpoints and acceptance test user journey coverage. emit BLOCKERS and NITPICKS."
    │  │   │   └─ · cached
-   │  │   └─ r5: npx rhachet enroll claude --roles ergonomist,mechanic -p "review the blueprint for experiential and visual blemishes in snapshotted acceptance test journeys. emit BLOCKERS and NITPICKS."
+   │  │   └─ r5: npx rhachet enroll claude --roles behaver,ergonomist,mechanic -p "review the blueprint for experiential and visual blemishes in snapshotted acceptance test journeys. emit BLOCKERS and NITPICKS."
    │  │       └─ · cached
    │  └─ judges
    │      ├─ j1: npx rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3
@@ -613,19 +613,19 @@ exports[`skill.init.behavior.guards.journey given: [case1] full behavior route w
    │  │   ├─ r2: npx rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with 'src/**/*' --paths-without '**/*.test.ts' --join intersect --output '$route/.reviews/$stone.peer-review.decode-friction.md' --mode hard
    │  │   │   ├─ finished [time] ✓
    │  │   │   └─ review: .route/5.1.execution.phase0_to_phaseN.guard.review.i1.2548bf19ddcb3f0d1f63f1f7efaa903490509acc8ff14f2bc5a829d5b8c64c7f.r2.md
-   │  │   ├─ r3: npx rhachet enroll claude --roles architect,mechanic -p "review the diff for architectural gaps and defects. emit BLOCKERS and NITPICKS."
+   │  │   ├─ r3: npx rhachet enroll claude --roles behaver,architect,mechanic -p "review the diff for architectural gaps and defects. emit BLOCKERS and NITPICKS."
    │  │   │   ├─ finished [time] ✓
    │  │   │   └─ review: .route/5.1.execution.phase0_to_phaseN.guard.review.i1.2548bf19ddcb3f0d1f63f1f7efaa903490509acc8ff14f2bc5a829d5b8c64c7f.r3.md
-   │  │   ├─ r4: npx rhachet enroll claude --roles architect,mechanic -p "review diff for architectural scope leak, decompose to reuse opportunities, and other arch smells. emit BLOCKERS and NITPICKS."
+   │  │   ├─ r4: npx rhachet enroll claude --roles behaver,architect,mechanic -p "review diff for architectural scope leak, decompose to reuse opportunities, and other arch smells. emit BLOCKERS and NITPICKS."
    │  │   │   ├─ finished [time] ✓
    │  │   │   └─ review: .route/5.1.execution.phase0_to_phaseN.guard.review.i1.2548bf19ddcb3f0d1f63f1f7efaa903490509acc8ff14f2bc5a829d5b8c64c7f.r4.md
-   │  │   ├─ r5: npx rhachet enroll claude --roles ergonomist,mechanic -p "review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage. emit BLOCKERS and NITPICKS."
+   │  │   ├─ r5: npx rhachet enroll claude --roles behaver,ergonomist,mechanic -p "review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage. emit BLOCKERS and NITPICKS."
    │  │   │   ├─ finished [time] ✓
    │  │   │   └─ review: .route/5.1.execution.phase0_to_phaseN.guard.review.i1.2548bf19ddcb3f0d1f63f1f7efaa903490509acc8ff14f2bc5a829d5b8c64c7f.r5.md
-   │  │   ├─ r6: npx rhachet enroll claude --roles ergonomist,mechanic -p "review the diff for experiential and visual blemishes in snapshotted acceptance test journeys. emit BLOCKERS and NITPICKS."
+   │  │   ├─ r6: npx rhachet enroll claude --roles behaver,ergonomist,mechanic -p "review the diff for experiential and visual blemishes in snapshotted acceptance test journeys. emit BLOCKERS and NITPICKS."
    │  │   │   ├─ finished [time] ✓
    │  │   │   └─ review: .route/5.1.execution.phase0_to_phaseN.guard.review.i1.2548bf19ddcb3f0d1f63f1f7efaa903490509acc8ff14f2bc5a829d5b8c64c7f.r6.md
-   │  │   └─ r7: npx rhachet enroll claude --roles architect,mechanic -p "review the current src/ implementation against the wish and vision. identify gaps where requirements are not addressed and omissions where features are missing. emit BLOCKERS and NITPICKS."
+   │  │   └─ r7: npx rhachet enroll claude --roles behaver,architect,mechanic -p "review the current src/ implementation against the wish and vision. identify gaps where requirements are not addressed and omissions where features are missing. emit BLOCKERS and NITPICKS."
    │  │       ├─ finished [time] ✓
    │  │       └─ review: .route/5.1.execution.phase0_to_phaseN.guard.review.i1.2548bf19ddcb3f0d1f63f1f7efaa903490509acc8ff14f2bc5a829d5b8c64c7f.r7.md
    │  └─ judges

--- a/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.heavy
+++ b/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.heavy
@@ -514,10 +514,10 @@ reviews:
 
   peer:
     - npx rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '$route/3.3.blueprint.*.md' --join intersect --output '$route/.reviews/$stone.peer-review.failhides.md' --mode hard
-    - npx rhachet enroll claude --roles architect,mechanic -p "review the blueprint at $route/$stone.md for architectural gaps and defects. emit BLOCKERS and NITPICKS."
-    - npx rhachet enroll claude --roles architect,mechanic -p "review diff for architectural scope leak, decompose to reuse opportunities, and other arch smells. emit BLOCKERS and NITPICKS."
-    - npx rhachet enroll claude --roles ergonomist,mechanic -p "review the blueprint for snapshot coverage on contract endpoints and acceptance test user journey coverage. emit BLOCKERS and NITPICKS."
-    - npx rhachet enroll claude --roles ergonomist,mechanic -p "review the blueprint for experiential and visual blemishes in snapshotted acceptance test journeys. emit BLOCKERS and NITPICKS."
+    - npx rhachet enroll claude --roles behaver,architect,mechanic -p "review the blueprint at $route/$stone.md for architectural gaps and defects. emit BLOCKERS and NITPICKS."
+    - npx rhachet enroll claude --roles behaver,architect,mechanic -p "review diff for architectural scope leak, decompose to reuse opportunities, and other arch smells. emit BLOCKERS and NITPICKS."
+    - npx rhachet enroll claude --roles behaver,ergonomist,mechanic -p "review the blueprint for snapshot coverage on contract endpoints and acceptance test user journey coverage. emit BLOCKERS and NITPICKS."
+    - npx rhachet enroll claude --roles behaver,ergonomist,mechanic -p "review the blueprint for experiential and visual blemishes in snapshotted acceptance test journeys. emit BLOCKERS and NITPICKS."
 
 judges:
   - npx rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3

--- a/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.light
+++ b/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.light
@@ -462,10 +462,10 @@ reviews:
 
   peer:
     - npx rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '$route/3.3.blueprint.*.md' --join intersect --output '$route/.reviews/$stone.peer-review.failhides.md' --mode hard
-    - npx rhachet enroll claude --roles architect,mechanic -p "review the blueprint at $route/$stone.md for architectural gaps and defects. emit BLOCKERS and NITPICKS."
-    - npx rhachet enroll claude --roles architect,mechanic -p "review diff for architectural scope leak, decompose to reuse opportunities, and other arch smells. emit BLOCKERS and NITPICKS."
-    - npx rhachet enroll claude --roles ergonomist,mechanic -p "review the blueprint for snapshot coverage on contract endpoints and acceptance test user journey coverage. emit BLOCKERS and NITPICKS."
-    - npx rhachet enroll claude --roles ergonomist,mechanic -p "review the blueprint for experiential and visual blemishes in snapshotted acceptance test journeys. emit BLOCKERS and NITPICKS."
+    - npx rhachet enroll claude --roles behaver,architect,mechanic -p "review the blueprint at $route/$stone.md for architectural gaps and defects. emit BLOCKERS and NITPICKS."
+    - npx rhachet enroll claude --roles behaver,architect,mechanic -p "review diff for architectural scope leak, decompose to reuse opportunities, and other arch smells. emit BLOCKERS and NITPICKS."
+    - npx rhachet enroll claude --roles behaver,ergonomist,mechanic -p "review the blueprint for snapshot coverage on contract endpoints and acceptance test user journey coverage. emit BLOCKERS and NITPICKS."
+    - npx rhachet enroll claude --roles behaver,ergonomist,mechanic -p "review the blueprint for experiential and visual blemishes in snapshotted acceptance test journeys. emit BLOCKERS and NITPICKS."
 
 judges:
   - npx rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3

--- a/src/domain.operations/behavior/init/templates/5.1.execution.from_vision.guard
+++ b/src/domain.operations/behavior/init/templates/5.1.execution.from_vision.guard
@@ -154,11 +154,11 @@ reviews:
 
   peer:
     - npx rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with 'src/**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.failhides.md' --mode hard
-    - npx rhachet enroll claude --roles architect,mechanic -p "review the diff for architectural gaps and defects. emit BLOCKERS and NITPICKS."
-    - npx rhachet enroll claude --roles architect,mechanic -p "review diff for architectural scope leak, decompose to reuse opportunities, and other arch smells. emit BLOCKERS and NITPICKS."
-    - npx rhachet enroll claude --roles ergonomist,mechanic -p "review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage. emit BLOCKERS and NITPICKS."
-    - npx rhachet enroll claude --roles ergonomist,mechanic -p "review the diff for experiential and visual blemishes in snapshotted acceptance test journeys. emit BLOCKERS and NITPICKS."
-    - npx rhachet enroll claude --roles architect,mechanic -p "review the current src/ implementation against the wish and vision. identify gaps where requirements are not addressed and omissions where features are missing. emit BLOCKERS and NITPICKS."
+    - npx rhachet enroll claude --roles behaver,architect,mechanic -p "review the diff for architectural gaps and defects. emit BLOCKERS and NITPICKS."
+    - npx rhachet enroll claude --roles behaver,architect,mechanic -p "review diff for architectural scope leak, decompose to reuse opportunities, and other arch smells. emit BLOCKERS and NITPICKS."
+    - npx rhachet enroll claude --roles behaver,ergonomist,mechanic -p "review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage. emit BLOCKERS and NITPICKS."
+    - npx rhachet enroll claude --roles behaver,ergonomist,mechanic -p "review the diff for experiential and visual blemishes in snapshotted acceptance test journeys. emit BLOCKERS and NITPICKS."
+    - npx rhachet enroll claude --roles behaver,architect,mechanic -p "review the current src/ implementation against the wish and vision. identify gaps where requirements are not addressed and omissions where features are missing. emit BLOCKERS and NITPICKS."
 
 judges:
   - npx rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3

--- a/src/domain.operations/behavior/init/templates/5.1.execution.phase0_to_phaseN.guard
+++ b/src/domain.operations/behavior/init/templates/5.1.execution.phase0_to_phaseN.guard
@@ -159,11 +159,11 @@ reviews:
   peer:
     - npx rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with 'src/**/*' --join intersect --output '$route/.reviews/$stone.peer-review.failhides.md' --mode hard
     - npx rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with 'src/**/*' --paths-without '**/*.test.ts' --join intersect --output '$route/.reviews/$stone.peer-review.decode-friction.md' --mode hard
-    - npx rhachet enroll claude --roles architect,mechanic -p "review the diff for architectural gaps and defects. emit BLOCKERS and NITPICKS."
-    - npx rhachet enroll claude --roles architect,mechanic -p "review diff for architectural scope leak, decompose to reuse opportunities, and other arch smells. emit BLOCKERS and NITPICKS."
-    - npx rhachet enroll claude --roles ergonomist,mechanic -p "review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage. emit BLOCKERS and NITPICKS."
-    - npx rhachet enroll claude --roles ergonomist,mechanic -p "review the diff for experiential and visual blemishes in snapshotted acceptance test journeys. emit BLOCKERS and NITPICKS."
-    - npx rhachet enroll claude --roles architect,mechanic -p "review the current src/ implementation against the wish and vision. identify gaps where requirements are not addressed and omissions where features are missing. emit BLOCKERS and NITPICKS."
+    - npx rhachet enroll claude --roles behaver,architect,mechanic -p "review the diff for architectural gaps and defects. emit BLOCKERS and NITPICKS."
+    - npx rhachet enroll claude --roles behaver,architect,mechanic -p "review diff for architectural scope leak, decompose to reuse opportunities, and other arch smells. emit BLOCKERS and NITPICKS."
+    - npx rhachet enroll claude --roles behaver,ergonomist,mechanic -p "review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage. emit BLOCKERS and NITPICKS."
+    - npx rhachet enroll claude --roles behaver,ergonomist,mechanic -p "review the diff for experiential and visual blemishes in snapshotted acceptance test journeys. emit BLOCKERS and NITPICKS."
+    - npx rhachet enroll claude --roles behaver,architect,mechanic -p "review the current src/ implementation against the wish and vision. identify gaps where requirements are not addressed and omissions where features are missing. emit BLOCKERS and NITPICKS."
 
 judges:
   - npx rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3


### PR DESCRIPTION
fix(templates): prefix peer review roles with behaver

- updated guard templates to use behaver,architect,mechanic instead of architect,mechanic
- updated guard templates to use behaver,ergonomist,mechanic instead of ergonomist,mechanic
- updated acceptance test snapshots

---
🐢🌊 surfed in by seaturtle[bot]