### PR TITLE
fix(cicd): add EHMPATH_BEAVER_GITHUB_TOKEN to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       BHUILD_DEMO_REPO_ACCESS_GITHUB_TOKEN: ${{ secrets.BHUILD_DEMO_REPO_ACCESS_GITHUB_TOKEN }}
+      EHMPATH_BEAVER_GITHUB_TOKEN: ${{ secrets.EHMPATH_BEAVER_GITHUB_TOKEN }}
 
   publish:
     uses: ./.github/workflows/.publish-npm.yml


### PR DESCRIPTION
fix(cicd): add EHMPATH_BEAVER_GITHUB_TOKEN to publish workflow

- the publish workflow was missing the keyrack token secret
- this caused integration tests to fail during npm publish

---
🐢🌊 surfed in by seaturtle[bot]