### PR TITLE
fix(guards): thread peer-review conversation via bhrain 0.30.1

### DIFF
--- a/blackbox/role=behaver/__snapshots__/skill.init.behavior.guards.acceptance.test.ts.snap
+++ b/blackbox/role=behaver/__snapshots__/skill.init.behavior.guards.acceptance.test.ts.snap
@@ -89,7 +89,8 @@ exports[`skill.init.behavior.guards.journey given: [case1] full behavior route w
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ /review/self/for.1.vision._.r1.has-grounded-in-reality.md
+   │  │  ├─ /review/self/for.1.vision._.r1.has-grounded-in-reality.md
+   │  │  └─ the guard looks precisely here, write exactly to this path
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -210,7 +211,8 @@ exports[`skill.init.behavior.guards.journey given: [case1] full behavior route w
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ /review/self/for.2.1.criteria.blackbox._.r1.has-questioned-requirements.md
+   │  │  ├─ /review/self/for.2.1.criteria.blackbox._.r1.has-questioned-requirements.md
+   │  │  └─ the guard looks precisely here, write exactly to this path
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -341,7 +343,8 @@ exports[`skill.init.behavior.guards.journey given: [case1] full behavior route w
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ /review/self/for.3.3.1.blueprint.product._.r1.has-research-citations.md
+   │  │  ├─ /review/self/for.3.3.1.blueprint.product._.r1.has-research-citations.md
+   │  │  └─ the guard looks precisely here, write exactly to this path
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -375,73 +378,85 @@ exports[`skill.init.behavior.guards.journey given: [case1] full behavior route w
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r1._.given.by_peer.repo-rules.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r001._.given.by_peer.repo-rules.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r001._.taken.by_self.repo-rules.md
    │
    ├─ r2: mech-failhides (l1, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r2._.given.by_peer.mech-failhides.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r002._.given.by_peer.mech-failhides.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r002._.taken.by_self.mech-failhides.md
    │
    ├─ r3: mech-decode-friction (l1, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r3._.given.by_peer.mech-decode-friction.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r003._.given.by_peer.mech-decode-friction.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r003._.taken.by_self.mech-decode-friction.md
    │
    ├─ r4: arch-opport-decomposition (l1, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r4._.given.by_peer.arch-opport-decomposition.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r004._.given.by_peer.arch-opport-decomposition.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r004._.taken.by_self.arch-opport-decomposition.md
    │
    ├─ r5: arch-smell-scopeleaks (l1, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r5._.given.by_peer.arch-smell-scopeleaks.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r005._.given.by_peer.arch-smell-scopeleaks.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r005._.taken.by_self.arch-smell-scopeleaks.md
    │
    ├─ r6: arch-hazards-maintenance (l1, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r6._.given.by_peer.arch-hazards-maintenance.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r006._.given.by_peer.arch-hazards-maintenance.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r006._.taken.by_self.arch-hazards-maintenance.md
    │
    ├─ r7: arch-hazards-behavior (l1, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r7._.given.by_peer.arch-hazards-behavior.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r007._.given.by_peer.arch-hazards-behavior.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r007._.taken.by_self.arch-hazards-behavior.md
    │
    ├─ r8: arch-ambiguous-terms (l1, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r8._.given.by_peer.arch-ambiguous-terms.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r008._.given.by_peer.arch-ambiguous-terms.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r008._.taken.by_self.arch-ambiguous-terms.md
    │
    ├─ r9: ergo-acceptance-journey-coverage (l1, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r9._.given.by_peer.ergo-acceptance-journey-coverage.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r009._.given.by_peer.ergo-acceptance-journey-coverage.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r009._.taken.by_self.ergo-acceptance-journey-coverage.md
    │
    ├─ r10: ergo-snapshot-visual-blemishes (l1, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r10._.given.by_peer.ergo-snapshot-visual-blemishes.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r010._.given.by_peer.ergo-snapshot-visual-blemishes.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r010._.taken.by_self.ergo-snapshot-visual-blemishes.md
    │
    ├─ r11: enroll-blueprint-arch-defects (l3, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r11._.given.by_peer.enroll-blueprint-arch-defects.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r011._.given.by_peer.enroll-blueprint-arch-defects.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r011._.taken.by_self.enroll-blueprint-arch-defects.md
    │
    ├─ r12: enroll-blueprint-behavior-intent (l3, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r12._.given.by_peer.enroll-blueprint-behavior-intent.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r012._.given.by_peer.enroll-blueprint-behavior-intent.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r012._.taken.by_self.enroll-blueprint-behavior-intent.md
    │
    ├─ ✓ judge.1 - allowed [time]
    │
@@ -458,62 +473,74 @@ exports[`skill.init.behavior.guards.journey given: [case1] full behavior route w
       │   │   ├─ approved [time]
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r1._.given.by_peer.repo-rules.md
+      │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r001._.given.by_peer.repo-rules.md
+      │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r001._.taken.by_self.repo-rules.md
       │   ├─ r2: mech-failhides (l1, 1/3)
       │   │   ├─ approved [time]
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r2._.given.by_peer.mech-failhides.md
+      │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r002._.given.by_peer.mech-failhides.md
+      │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r002._.taken.by_self.mech-failhides.md
       │   ├─ r3: mech-decode-friction (l1, 1/3)
       │   │   ├─ approved [time]
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r3._.given.by_peer.mech-decode-friction.md
+      │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r003._.given.by_peer.mech-decode-friction.md
+      │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r003._.taken.by_self.mech-decode-friction.md
       │   ├─ r4: arch-opport-decomposition (l1, 1/3)
       │   │   ├─ approved [time]
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r4._.given.by_peer.arch-opport-decomposition.md
+      │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r004._.given.by_peer.arch-opport-decomposition.md
+      │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r004._.taken.by_self.arch-opport-decomposition.md
       │   ├─ r5: arch-smell-scopeleaks (l1, 1/3)
       │   │   ├─ approved [time]
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r5._.given.by_peer.arch-smell-scopeleaks.md
+      │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r005._.given.by_peer.arch-smell-scopeleaks.md
+      │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r005._.taken.by_self.arch-smell-scopeleaks.md
       │   ├─ r6: arch-hazards-maintenance (l1, 1/3)
       │   │   ├─ approved [time]
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r6._.given.by_peer.arch-hazards-maintenance.md
+      │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r006._.given.by_peer.arch-hazards-maintenance.md
+      │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r006._.taken.by_self.arch-hazards-maintenance.md
       │   ├─ r7: arch-hazards-behavior (l1, 1/3)
       │   │   ├─ approved [time]
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r7._.given.by_peer.arch-hazards-behavior.md
+      │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r007._.given.by_peer.arch-hazards-behavior.md
+      │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r007._.taken.by_self.arch-hazards-behavior.md
       │   ├─ r8: arch-ambiguous-terms (l1, 1/3)
       │   │   ├─ approved [time]
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r8._.given.by_peer.arch-ambiguous-terms.md
+      │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r008._.given.by_peer.arch-ambiguous-terms.md
+      │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r008._.taken.by_self.arch-ambiguous-terms.md
       │   ├─ r9: ergo-acceptance-journey-coverage (l1, 1/3)
       │   │   ├─ approved [time]
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r9._.given.by_peer.ergo-acceptance-journey-coverage.md
+      │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r009._.given.by_peer.ergo-acceptance-journey-coverage.md
+      │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r009._.taken.by_self.ergo-acceptance-journey-coverage.md
       │   ├─ r10: ergo-snapshot-visual-blemishes (l1, 1/3)
       │   │   ├─ approved [time]
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r10._.given.by_peer.ergo-snapshot-visual-blemishes.md
+      │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r010._.given.by_peer.ergo-snapshot-visual-blemishes.md
+      │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r010._.taken.by_self.ergo-snapshot-visual-blemishes.md
       │   ├─ r11: enroll-blueprint-arch-defects (l3, 1/3)
       │   │   ├─ approved [time]
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r11._.given.by_peer.enroll-blueprint-arch-defects.md
+      │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r011._.given.by_peer.enroll-blueprint-arch-defects.md
+      │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r011._.taken.by_self.enroll-blueprint-arch-defects.md
       │   └─ r12: enroll-blueprint-behavior-intent (l3, 1/3)
       │       ├─ approved [time]
       │       ├─ 0 blockers ✓
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r12._.given.by_peer.enroll-blueprint-behavior-intent.md
+      │       ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r012._.given.by_peer.enroll-blueprint-behavior-intent.md
+      │       └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r012._.taken.by_self.enroll-blueprint-behavior-intent.md
       └─ judges
           ├─ j1: $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3
           │   └─ finished [time] ✓
@@ -563,73 +590,85 @@ exports[`skill.init.behavior.guards.journey given: [case1] full behavior route w
    │   ├─ approved, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r1._.given.by_peer.repo-rules.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r001._.given.by_peer.repo-rules.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r001._.taken.by_self.repo-rules.md
    │
    ├─ r2: mech-failhides (l1, 1/3)
    │   ├─ approved, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r2._.given.by_peer.mech-failhides.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r002._.given.by_peer.mech-failhides.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r002._.taken.by_self.mech-failhides.md
    │
    ├─ r3: mech-decode-friction (l1, 1/3)
    │   ├─ approved, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r3._.given.by_peer.mech-decode-friction.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r003._.given.by_peer.mech-decode-friction.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r003._.taken.by_self.mech-decode-friction.md
    │
    ├─ r4: arch-opport-decomposition (l1, 1/3)
    │   ├─ approved, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r4._.given.by_peer.arch-opport-decomposition.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r004._.given.by_peer.arch-opport-decomposition.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r004._.taken.by_self.arch-opport-decomposition.md
    │
    ├─ r5: arch-smell-scopeleaks (l1, 1/3)
    │   ├─ approved, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r5._.given.by_peer.arch-smell-scopeleaks.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r005._.given.by_peer.arch-smell-scopeleaks.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r005._.taken.by_self.arch-smell-scopeleaks.md
    │
    ├─ r6: arch-hazards-maintenance (l1, 1/3)
    │   ├─ approved, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r6._.given.by_peer.arch-hazards-maintenance.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r006._.given.by_peer.arch-hazards-maintenance.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r006._.taken.by_self.arch-hazards-maintenance.md
    │
    ├─ r7: arch-hazards-behavior (l1, 1/3)
    │   ├─ approved, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r7._.given.by_peer.arch-hazards-behavior.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r007._.given.by_peer.arch-hazards-behavior.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r007._.taken.by_self.arch-hazards-behavior.md
    │
    ├─ r8: arch-ambiguous-terms (l1, 1/3)
    │   ├─ approved, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r8._.given.by_peer.arch-ambiguous-terms.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r008._.given.by_peer.arch-ambiguous-terms.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r008._.taken.by_self.arch-ambiguous-terms.md
    │
    ├─ r9: ergo-acceptance-journey-coverage (l1, 1/3)
    │   ├─ approved, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r9._.given.by_peer.ergo-acceptance-journey-coverage.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r009._.given.by_peer.ergo-acceptance-journey-coverage.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r009._.taken.by_self.ergo-acceptance-journey-coverage.md
    │
    ├─ r10: ergo-snapshot-visual-blemishes (l1, 1/3)
    │   ├─ approved, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r10._.given.by_peer.ergo-snapshot-visual-blemishes.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r010._.given.by_peer.ergo-snapshot-visual-blemishes.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r010._.taken.by_self.ergo-snapshot-visual-blemishes.md
    │
    ├─ r11: enroll-blueprint-arch-defects (l3, 1/3)
    │   ├─ approved, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r11._.given.by_peer.enroll-blueprint-arch-defects.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r011._.given.by_peer.enroll-blueprint-arch-defects.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r011._.taken.by_self.enroll-blueprint-arch-defects.md
    │
    ├─ r12: enroll-blueprint-behavior-intent (l3, 1/3)
    │   ├─ approved, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r12._.given.by_peer.enroll-blueprint-behavior-intent.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r012._.given.by_peer.enroll-blueprint-behavior-intent.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r012._.taken.by_self.enroll-blueprint-behavior-intent.md
    │
    ├─ ✓ judge.1 - allowed [time]
    │
@@ -645,62 +684,74 @@ exports[`skill.init.behavior.guards.journey given: [case1] full behavior route w
    │  │   │   ├─ approved, cached
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r1._.given.by_peer.repo-rules.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r001._.given.by_peer.repo-rules.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r001._.taken.by_self.repo-rules.md
    │  │   ├─ r2: mech-failhides (l1, 1/3)
    │  │   │   ├─ approved, cached
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r2._.given.by_peer.mech-failhides.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r002._.given.by_peer.mech-failhides.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r002._.taken.by_self.mech-failhides.md
    │  │   ├─ r3: mech-decode-friction (l1, 1/3)
    │  │   │   ├─ approved, cached
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r3._.given.by_peer.mech-decode-friction.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r003._.given.by_peer.mech-decode-friction.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r003._.taken.by_self.mech-decode-friction.md
    │  │   ├─ r4: arch-opport-decomposition (l1, 1/3)
    │  │   │   ├─ approved, cached
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r4._.given.by_peer.arch-opport-decomposition.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r004._.given.by_peer.arch-opport-decomposition.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r004._.taken.by_self.arch-opport-decomposition.md
    │  │   ├─ r5: arch-smell-scopeleaks (l1, 1/3)
    │  │   │   ├─ approved, cached
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r5._.given.by_peer.arch-smell-scopeleaks.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r005._.given.by_peer.arch-smell-scopeleaks.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r005._.taken.by_self.arch-smell-scopeleaks.md
    │  │   ├─ r6: arch-hazards-maintenance (l1, 1/3)
    │  │   │   ├─ approved, cached
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r6._.given.by_peer.arch-hazards-maintenance.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r006._.given.by_peer.arch-hazards-maintenance.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r006._.taken.by_self.arch-hazards-maintenance.md
    │  │   ├─ r7: arch-hazards-behavior (l1, 1/3)
    │  │   │   ├─ approved, cached
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r7._.given.by_peer.arch-hazards-behavior.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r007._.given.by_peer.arch-hazards-behavior.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r007._.taken.by_self.arch-hazards-behavior.md
    │  │   ├─ r8: arch-ambiguous-terms (l1, 1/3)
    │  │   │   ├─ approved, cached
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r8._.given.by_peer.arch-ambiguous-terms.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r008._.given.by_peer.arch-ambiguous-terms.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r008._.taken.by_self.arch-ambiguous-terms.md
    │  │   ├─ r9: ergo-acceptance-journey-coverage (l1, 1/3)
    │  │   │   ├─ approved, cached
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r9._.given.by_peer.ergo-acceptance-journey-coverage.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r009._.given.by_peer.ergo-acceptance-journey-coverage.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r009._.taken.by_self.ergo-acceptance-journey-coverage.md
    │  │   ├─ r10: ergo-snapshot-visual-blemishes (l1, 1/3)
    │  │   │   ├─ approved, cached
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r10._.given.by_peer.ergo-snapshot-visual-blemishes.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r010._.given.by_peer.ergo-snapshot-visual-blemishes.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r010._.taken.by_self.ergo-snapshot-visual-blemishes.md
    │  │   ├─ r11: enroll-blueprint-arch-defects (l3, 1/3)
    │  │   │   ├─ approved, cached
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r11._.given.by_peer.enroll-blueprint-arch-defects.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r011._.given.by_peer.enroll-blueprint-arch-defects.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r011._.taken.by_self.enroll-blueprint-arch-defects.md
    │  │   └─ r12: enroll-blueprint-behavior-intent (l3, 1/3)
    │  │       ├─ approved, cached
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i1.{HASH}.r12._.given.by_peer.enroll-blueprint-behavior-intent.md
+   │  │       ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r012._.given.by_peer.enroll-blueprint-behavior-intent.md
+   │  │       └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/3.3.1.blueprint.product._.review.i001.{HASH}.r012._.taken.by_self.enroll-blueprint-behavior-intent.md
    │  └─ judges
    │      ├─ j1: $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3
    │      │   └─ finished [time] ✓
@@ -791,7 +842,8 @@ exports[`skill.init.behavior.guards.journey given: [case1] full behavior route w
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ /review/self/for.5.1.execution.phase0_to_phaseN._.r1.has-pruned-yagni.md
+   │  │  ├─ /review/self/for.5.1.execution.phase0_to_phaseN._.r1.has-pruned-yagni.md
+   │  │  └─ the guard looks precisely here, write exactly to this path
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -825,67 +877,78 @@ exports[`skill.init.behavior.guards.journey given: [case1] full behavior route w
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r1._.given.by_peer.repo-rules.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r001._.given.by_peer.repo-rules.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r001._.taken.by_self.repo-rules.md
    │
    ├─ r2: mech-failhides (l1, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r2._.given.by_peer.mech-failhides.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r002._.given.by_peer.mech-failhides.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r002._.taken.by_self.mech-failhides.md
    │
    ├─ r3: mech-decode-friction (l1, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r3._.given.by_peer.mech-decode-friction.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r003._.given.by_peer.mech-decode-friction.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r003._.taken.by_self.mech-decode-friction.md
    │
    ├─ r4: arch-opport-decomposition (l1, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r4._.given.by_peer.arch-opport-decomposition.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r004._.given.by_peer.arch-opport-decomposition.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r004._.taken.by_self.arch-opport-decomposition.md
    │
    ├─ r5: arch-smell-scopeleaks (l1, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r5._.given.by_peer.arch-smell-scopeleaks.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r005._.given.by_peer.arch-smell-scopeleaks.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r005._.taken.by_self.arch-smell-scopeleaks.md
    │
    ├─ r6: arch-hazards-maintenance (l1, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r6._.given.by_peer.arch-hazards-maintenance.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r006._.given.by_peer.arch-hazards-maintenance.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r006._.taken.by_self.arch-hazards-maintenance.md
    │
    ├─ r7: arch-hazards-behavior (l1, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r7._.given.by_peer.arch-hazards-behavior.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r007._.given.by_peer.arch-hazards-behavior.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r007._.taken.by_self.arch-hazards-behavior.md
    │
    ├─ r8: behavior-intent-coverage (l1, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r8._.given.by_peer.behavior-intent-coverage.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r008._.given.by_peer.behavior-intent-coverage.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r008._.taken.by_self.behavior-intent-coverage.md
    │
    ├─ r9: ergo-friction-hazards (l1, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r9._.given.by_peer.ergo-friction-hazards.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r009._.given.by_peer.ergo-friction-hazards.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r009._.taken.by_self.ergo-friction-hazards.md
    │
    ├─ r10: enroll-impl-behavior-intent (l3, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r10._.given.by_peer.enroll-impl-behavior-intent.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r010._.given.by_peer.enroll-impl-behavior-intent.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r010._.taken.by_self.enroll-impl-behavior-intent.md
    │
    ├─ r11: enroll-impl-arch-defects (l3, 1/3)
    │   ├─ approved [time]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r11._.given.by_peer.enroll-impl-arch-defects.md
+   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r011._.given.by_peer.enroll-impl-arch-defects.md
+   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r011._.taken.by_self.enroll-impl-arch-defects.md
    │
    └─ ✓ judge.1 - allowed [time]
 
@@ -901,57 +964,68 @@ exports[`skill.init.behavior.guards.journey given: [case1] full behavior route w
    │  │   │   ├─ approved [time]
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r1._.given.by_peer.repo-rules.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r001._.given.by_peer.repo-rules.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r001._.taken.by_self.repo-rules.md
    │  │   ├─ r2: mech-failhides (l1, 1/3)
    │  │   │   ├─ approved [time]
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r2._.given.by_peer.mech-failhides.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r002._.given.by_peer.mech-failhides.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r002._.taken.by_self.mech-failhides.md
    │  │   ├─ r3: mech-decode-friction (l1, 1/3)
    │  │   │   ├─ approved [time]
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r3._.given.by_peer.mech-decode-friction.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r003._.given.by_peer.mech-decode-friction.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r003._.taken.by_self.mech-decode-friction.md
    │  │   ├─ r4: arch-opport-decomposition (l1, 1/3)
    │  │   │   ├─ approved [time]
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r4._.given.by_peer.arch-opport-decomposition.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r004._.given.by_peer.arch-opport-decomposition.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r004._.taken.by_self.arch-opport-decomposition.md
    │  │   ├─ r5: arch-smell-scopeleaks (l1, 1/3)
    │  │   │   ├─ approved [time]
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r5._.given.by_peer.arch-smell-scopeleaks.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r005._.given.by_peer.arch-smell-scopeleaks.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r005._.taken.by_self.arch-smell-scopeleaks.md
    │  │   ├─ r6: arch-hazards-maintenance (l1, 1/3)
    │  │   │   ├─ approved [time]
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r6._.given.by_peer.arch-hazards-maintenance.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r006._.given.by_peer.arch-hazards-maintenance.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r006._.taken.by_self.arch-hazards-maintenance.md
    │  │   ├─ r7: arch-hazards-behavior (l1, 1/3)
    │  │   │   ├─ approved [time]
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r7._.given.by_peer.arch-hazards-behavior.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r007._.given.by_peer.arch-hazards-behavior.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r007._.taken.by_self.arch-hazards-behavior.md
    │  │   ├─ r8: behavior-intent-coverage (l1, 1/3)
    │  │   │   ├─ approved [time]
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r8._.given.by_peer.behavior-intent-coverage.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r008._.given.by_peer.behavior-intent-coverage.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r008._.taken.by_self.behavior-intent-coverage.md
    │  │   ├─ r9: ergo-friction-hazards (l1, 1/3)
    │  │   │   ├─ approved [time]
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r9._.given.by_peer.ergo-friction-hazards.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r009._.given.by_peer.ergo-friction-hazards.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r009._.taken.by_self.ergo-friction-hazards.md
    │  │   ├─ r10: enroll-impl-behavior-intent (l3, 1/3)
    │  │   │   ├─ approved [time]
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r10._.given.by_peer.enroll-impl-behavior-intent.md
+   │  │   │   ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r010._.given.by_peer.enroll-impl-behavior-intent.md
+   │  │   │   └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r010._.taken.by_self.enroll-impl-behavior-intent.md
    │  │   └─ r11: enroll-impl-arch-defects (l3, 1/3)
    │  │       ├─ approved [time]
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.{HASH}.r11._.given.by_peer.enroll-impl-arch-defects.md
+   │  │       ├─ given: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r011._.given.by_peer.enroll-impl-arch-defects.md
+   │  │       └─ taken: .behavior/v{DATE}.full-journey/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i001.{HASH}.r011._.taken.by_self.enroll-impl-arch-defects.md
    │  └─ judges
    │      └─ j1: $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3
    │          └─ finished [time] ✓

--- a/blackbox/role=behaver/skill.init.behavior.guards.acceptance.test.ts
+++ b/blackbox/role=behaver/skill.init.behavior.guards.acceptance.test.ts
@@ -215,7 +215,7 @@ const genConsumerRepoWithBhrain = (input: {
         version: '1.0.0',
         dependencies: {
           'rhachet-roles-bhuild': `file:${process.cwd()}`,
-          'rhachet-roles-bhrain': '>=0.28.0',
+          'rhachet-roles-bhrain': '0.30.1',
           'rhachet-roles-ehmpathy': '>=1.34.0',
           rhachet: '^1.15.0',
         },

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "rhachet-brains-anthropic": "0.4.1",
     "rhachet-brains-fireworksai": "0.1.3",
     "rhachet-brains-xai": "0.3.3",
-    "rhachet-roles-bhrain": "0.29.24",
+    "rhachet-roles-bhrain": "0.30.1",
     "rhachet-roles-bhuild": "link:.",
     "rhachet-roles-ehmpathy": "1.38.1",
     "rhachet-roles-rhachet": "0.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,8 +94,8 @@ importers:
         specifier: 0.3.3
         version: 0.3.3(rhachet@1.43.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4))
       rhachet-roles-bhrain:
-        specifier: 0.29.24
-        version: 0.29.24(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.3(rhachet@1.43.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4)))(rhachet@1.43.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4))
+        specifier: 0.30.1
+        version: 0.30.1(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.3(rhachet@1.43.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4)))(rhachet@1.43.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4))
       rhachet-roles-bhuild:
         specifier: link:.
         version: 'link:'
@@ -4255,8 +4255,8 @@ packages:
     peerDependencies:
       rhachet: '>=1.21.4'
 
-  rhachet-roles-bhrain@0.29.24:
-    resolution: {integrity: sha512-5piQKk+sNU7KQ+G5pvYEV4qE7uU/HyTO79692MvsqIOd1SG69+S3ncNTHX2reVD2JFGUOMV3OP4t6LdsW6GNGw==}
+  rhachet-roles-bhrain@0.30.1:
+    resolution: {integrity: sha512-NNeSIxLDxgvlCkOSf6ZGDiT/l9dvmT5plGaHZEt62zJJb+IuFqsbC5ZIZU2izsdfY/rY5wqmWAA+tTXPkWhi8g==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
       rhachet: '>=1.41.21'
@@ -9909,7 +9909,7 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
-  rhachet-roles-bhrain@0.29.24(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.3(rhachet@1.43.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4)))(rhachet@1.43.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4)):
+  rhachet-roles-bhrain@0.30.1(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.3(rhachet@1.43.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4)))(rhachet@1.43.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4)):
     dependencies:
       '@ehmpathy/as-command': 1.0.3
       '@ehmpathy/uni-time': 1.8.1

--- a/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.heavy
+++ b/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.heavy
@@ -516,68 +516,68 @@ reviews:
     # --- level 1: cheap reviewers (run first, in parallel) ---
 
     - slug: repo-rules
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: mech-failhides
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: mech-decode-friction
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     # --- architect reviews (level 1) ---
 
     - slug: arch-opport-decomposition
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: arch-smell-scopeleaks
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: arch-hazards-maintenance
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: arch-hazards-behavior
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: arch-ambiguous-terms
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.ambiguous-terms.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/ubiqlang.ambiguous-from-overload.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.terms/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.ambiguous-terms.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/ubiqlang.ambiguous-from-overload.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.terms/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     # --- ergonomist reviews (level 1) ---
 
     - slug: ergo-acceptance-journey-coverage
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: ergo-snapshot-visual-blemishes
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     # --- level 3: expensive reviewers (run after level 1 is terminal) ---
 
     - slug: enroll-blueprint-arch-defects
-      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current blueprint for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally'
+      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current blueprint for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally. read the prior peer-review conversation at $conversation to catch up on context.'
       budget: 3
       level: 3
 
     - slug: enroll-blueprint-behavior-intent
-      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current blueprint for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps'
+      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current blueprint for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps. read the prior peer-review conversation at $conversation to catch up on context.'
       budget: 3
       level: 3
 

--- a/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.light
+++ b/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.light
@@ -464,68 +464,68 @@ reviews:
     # --- level 1: cheap reviewers (run first, in parallel) ---
 
     - slug: repo-rules
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: mech-failhides
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: mech-decode-friction
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     # --- architect reviews (level 1) ---
 
     - slug: arch-opport-decomposition
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: arch-smell-scopeleaks
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: arch-hazards-maintenance
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: arch-hazards-behavior
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: arch-ambiguous-terms
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.ambiguous-terms.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/ubiqlang.ambiguous-from-overload.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.terms/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.ambiguous-terms.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/ubiqlang.ambiguous-from-overload.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.terms/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     # --- ergonomist reviews (level 1) ---
 
     - slug: ergo-acceptance-journey-coverage
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: ergo-snapshot-visual-blemishes
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     # --- level 3: expensive reviewers (run after level 1 is terminal) ---
 
     - slug: enroll-blueprint-arch-defects
-      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current blueprint for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally'
+      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current blueprint for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally. read the prior peer-review conversation at $conversation to catch up on context.'
       budget: 3
       level: 3
 
     - slug: enroll-blueprint-behavior-intent
-      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current blueprint for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps'
+      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current blueprint for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps. read the prior peer-review conversation at $conversation to catch up on context.'
       budget: 3
       level: 3
 

--- a/src/domain.operations/behavior/init/templates/5.1.execution.from_vision.guard
+++ b/src/domain.operations/behavior/init/templates/5.1.execution.from_vision.guard
@@ -156,61 +156,61 @@ reviews:
     # --- level 1: cheap reviewers (run first, in parallel) ---
 
     - slug: repo-rules
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: mech-failhides
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: mech-decode-friction
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-without '**/*.test.ts' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-without '**/*.test.ts' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     # --- architect reviews (level 1) ---
 
     - slug: arch-opport-decomposition
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: arch-smell-scopeleaks
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: arch-hazards-maintenance
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: arch-hazards-behavior
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: behavior-intent-coverage
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md' --refs '$route/0.wish.md' --refs '$route/1.vision.yield.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.criteria/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md' --refs '$route/0.wish.md' --refs '$route/1.vision.yield.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.criteria/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: ergo-friction-hazards
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     # --- level 3: expensive reviewers (run after level 1 is terminal) ---
 
     - slug: enroll-impl-behavior-intent
-      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current implementation for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps'
+      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current implementation for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps. read the prior peer-review conversation at $conversation to catch up on context.'
       budget: 3
       level: 3
 
     - slug: enroll-impl-arch-defects
-      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current implementation for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally'
+      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current implementation for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally. read the prior peer-review conversation at $conversation to catch up on context.'
       budget: 3
       level: 3
 

--- a/src/domain.operations/behavior/init/templates/5.1.execution.phase0_to_phaseN.guard
+++ b/src/domain.operations/behavior/init/templates/5.1.execution.phase0_to_phaseN.guard
@@ -160,61 +160,61 @@ reviews:
     # --- level 1: cheap reviewers (run first, in parallel) ---
 
     - slug: repo-rules
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: mech-failhides
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: mech-decode-friction
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-without '**/*.test.ts' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-without '**/*.test.ts' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     # --- architect reviews (level 1) ---
 
     - slug: arch-opport-decomposition
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: arch-smell-scopeleaks
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: arch-hazards-maintenance
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: arch-hazards-behavior
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: behavior-intent-coverage
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md' --refs '$route/0.wish.md' --refs '$route/1.vision.yield.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.criteria/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md' --refs '$route/0.wish.md' --refs '$route/1.vision.yield.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.criteria/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: ergo-friction-hazards
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     # --- level 3: expensive reviewers (run after level 1 is terminal) ---
 
     - slug: enroll-impl-behavior-intent
-      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current implementation for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps'
+      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current implementation for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps. read the prior peer-review conversation at $conversation to catch up on context.'
       budget: 3
       level: 3
 
     - slug: enroll-impl-arch-defects
-      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current implementation for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally'
+      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current implementation for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally. read the prior peer-review conversation at $conversation to catch up on context.'
       budget: 3
       level: 3
 

--- a/src/domain.operations/behavior/init/templates/5.3.verification.guard
+++ b/src/domain.operations/behavior/init/templates/5.3.verification.guard
@@ -230,59 +230,59 @@ reviews:
     # --- level 1: cheap reviewers (run first, in parallel) ---
 
     - slug: repo-rules
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: ergo-contract-snapshots
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: mech-external-contracts
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.external-contract-integration-tests.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.remote-boundaries.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.external-contract-integration-tests.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.remote-boundaries.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: ergo-acceptance-journey-coverage
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: ergo-snapshot-visual-blemishes
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: mech-given-when-then
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/rule.require.given-when-then.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/criteria.given_when_then.[seed].v3.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/lessons.howto/*.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/rule.require.given-when-then.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/criteria.given_when_then.[seed].v3.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/lessons.howto/*.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: mech-test-intent
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.forbid.test-intent-violations.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/work.flow/refactor/rule.require.review-test-changes.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.forbid.test-intent-violations.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/work.flow/refactor/rule.require.review-test-changes.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     - slug: mech-test-scope-purity
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.*/rule.*.md' --diffs since-main --paths-with '{src,blackbox}/**/*.test.ts' --join intersect --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.*/rule.*.md' --diffs since-main --paths-with '{src,blackbox}/**/*.test.ts' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 
     # --- level 3: expensive reviewers (run after level 1 is terminal) ---
 
     - slug: enroll-verif-snapshot-coverage
-      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,ergonomist,mechanic -p 'review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage'
+      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,ergonomist,mechanic -p 'review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage. read the prior peer-review conversation at $conversation to catch up on context.'
       budget: 3
       level: 3
 
     - slug: enroll-verif-snapshot-blemishes
-      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,ergonomist,mechanic -p 'review the diff for experiential and visual blemishes in snapshotted acceptance test journeys'
+      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,ergonomist,mechanic -p 'review the diff for experiential and visual blemishes in snapshotted acceptance test journeys. read the prior peer-review conversation at $conversation to catch up on context.'
       budget: 3
       level: 3
 
     - slug: enroll-verif-test-intent
-      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current implementation for test intent violation diffs. if any of the diffs related to tests loosened assertions or changed the criteria, this is a blocker. tests were added for a reason. we have to maintain the behavior they locked in'
+      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current implementation for test intent violation diffs. if any of the diffs related to tests loosened assertions or changed the criteria, this is a blocker. tests were added for a reason. we have to maintain the behavior they locked in. read the prior peer-review conversation at $conversation to catch up on context.'
       budget: 3
       level: 3
 


### PR DESCRIPTION
fix(guards): thread peer-review conversation via bhrain 0.30.1

- add --conversation $conversation to L1 review reviewers in all 5 guard templates
- so peers converge on the driver [REPAIR]/[REFUTE] responses across rounds
- point L3 enroll brains to $conversation to catch up on prior review context
- pin rhachet-roles-bhrain to 0.30.1 (peer-review conversation floor)
- resnap guards snapshot for 0.30.1 output; prune stale hooks from settings.json

---
🐢🌊 surfed in by seaturtle[bot]