### PR TITLE
fix(guards): pass --optional rules to repo-rules reviewers (bhrain 0.30.4+)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -497,5 +497,10 @@
       "Bash(pnpm add:*)",
       "Bash(pnpm install:*)"
     ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "node -e \"import('rhachet-roles-bhrain/cli/route').then(m => m.routeStatusLine())\"",
+    "padding": 0
   }
 }

--- a/blackbox/role=behaver/skill.init.behavior.guards.acceptance.test.ts
+++ b/blackbox/role=behaver/skill.init.behavior.guards.acceptance.test.ts
@@ -942,5 +942,74 @@ describe('skill.init.behavior.guards.journey', () => {
         ]);
       });
     });
+
+    // ═══════════════════════════════════════════════════════════════
+    // REPO-RULES OPTIONAL-SKIP CONTRACT (the wish's actual payload)
+    // ═══════════════════════════════════════════════════════════════
+    when('[t11] every guard-template variant makes its repo-rules reviewer optional', () => {
+      // read the SOURCE guard templates directly so EVERY variant a caller
+      // could select is verified — not just the ones the heavy full-journey
+      // fixture happens to generate.
+      // .why = the repo-local ruleset (.agent/repo=.this/**/rule.*.md) is
+      //        legitimately empty in a fresh repo. absent --optional rules the
+      //        reviewer exits 2 and false-blocks the stone, which demands a
+      //        human overrule of an empty-by-design ruleset. a per-variant read
+      //        locks in the fix so a silent revert of ANY variant fails
+      //        (rule.require.contract-snapshot-exhaustiveness — the variant you
+      //        skip is the one that breaks in prod)
+      const templatesDir = path.join(
+        __dirname,
+        '../../src/domain.operations/behavior/init/templates',
+      );
+
+      const getRepoRulesLinesFromTemplates = (): {
+        template: string;
+        run: string;
+      }[] => {
+        const templateFiles = fs
+          .readdirSync(templatesDir)
+          .filter((f) => f.includes('.guard'));
+        return templateFiles.flatMap((template) => {
+          const content = fs.readFileSync(
+            path.join(templatesDir, template),
+            'utf-8',
+          );
+          // the repo-rules reviewer points --rules at the repo-local ruleset
+          const runLines = content
+            .split('\n')
+            .filter((line) => line.includes("--rules '.agent/repo=.this/"));
+          return runLines.map((run) => ({ template, run }));
+        });
+      };
+
+      then('every repo-rules reviewer across all variants passes --optional rules', () => {
+        const runLines = getRepoRulesLinesFromTemplates();
+
+        // guard against a false pass if the extraction matched no lines
+        expect(runLines.length).toBeGreaterThan(0);
+
+        // every repo-local ruleset reviewer must opt into the empty-rules skip
+        for (const line of runLines)
+          expect(line.run).toContain('--optional rules');
+      });
+
+      then('every selectable guard variant is covered by the roster', () => {
+        const runLines = getRepoRulesLinesFromTemplates();
+
+        // explicit lock-in that BOTH blueprint variants (light is the default),
+        // BOTH execution paths (from_vision is --size nano), and verification
+        // each carry a repo-rules reviewer the assertion above verified.
+        const templatesWithRepoRules = [
+          ...new Set(runLines.map((l) => l.template)),
+        ].sort();
+        expect(templatesWithRepoRules).toEqual([
+          '3.3.1.blueprint.product.guard.heavy',
+          '3.3.1.blueprint.product.guard.light',
+          '5.1.execution.from_vision.guard',
+          '5.1.execution.phase0_to_phaseN.guard',
+          '5.3.verification.guard',
+        ]);
+      });
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "rhachet-brains-xai": ">=0.3.3",
-    "rhachet-roles-bhrain": ">=0.12.1"
+    "rhachet-roles-bhrain": ">=0.30.4"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
@@ -96,7 +96,7 @@
     "rhachet-brains-anthropic": "0.4.1",
     "rhachet-brains-fireworksai": "0.1.3",
     "rhachet-brains-xai": "0.3.3",
-    "rhachet-roles-bhrain": "0.30.1",
+    "rhachet-roles-bhrain": "0.31.0",
     "rhachet-roles-bhuild": "link:.",
     "rhachet-roles-ehmpathy": "1.38.1",
     "rhachet-roles-rhachet": "0.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,8 +94,8 @@ importers:
         specifier: 0.3.3
         version: 0.3.3(rhachet@1.43.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4))
       rhachet-roles-bhrain:
-        specifier: 0.30.1
-        version: 0.30.1(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.3(rhachet@1.43.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4)))(rhachet@1.43.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4))
+        specifier: 0.31.0
+        version: 0.31.0(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.3(rhachet@1.43.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4)))(rhachet@1.43.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4))
       rhachet-roles-bhuild:
         specifier: link:.
         version: 'link:'
@@ -2784,6 +2784,10 @@ packages:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
 
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
+    engines: {node: '>=0.3.1'}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -4255,8 +4259,8 @@ packages:
     peerDependencies:
       rhachet: '>=1.21.4'
 
-  rhachet-roles-bhrain@0.30.1:
-    resolution: {integrity: sha512-NNeSIxLDxgvlCkOSf6ZGDiT/l9dvmT5plGaHZEt62zJJb+IuFqsbC5ZIZU2izsdfY/rY5wqmWAA+tTXPkWhi8g==}
+  rhachet-roles-bhrain@0.31.0:
+    resolution: {integrity: sha512-c9dxIarERG7bR//eUSQYxkAneF0eouolIlSGtAO62dEAzGWPn/bzxn/Obdfa1fHOBOJmC4V1/rtepxL3sKhIMw==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
       rhachet: '>=1.41.21'
@@ -8175,6 +8179,8 @@ snapshots:
   diff@4.0.2:
     optional: true
 
+  diff@9.0.0: {}
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -9909,12 +9915,13 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
-  rhachet-roles-bhrain@0.30.1(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.3(rhachet@1.43.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4)))(rhachet@1.43.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4)):
+  rhachet-roles-bhrain@0.31.0(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.3(rhachet@1.43.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4)))(rhachet@1.43.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4)):
     dependencies:
       '@ehmpathy/as-command': 1.0.3
       '@ehmpathy/uni-time': 1.8.1
       archiver: 7.0.1
       as-procedure: 1.1.7
+      diff: 9.0.0
       domain-objects: 0.31.9
       globby: 11.1.0
       hash-fns: 3.0.0

--- a/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.heavy
+++ b/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.heavy
@@ -516,7 +516,7 @@ reviews:
     # --- level 1: cheap reviewers (run first, in parallel) ---
 
     - slug: repo-rules
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --optional rules --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 

--- a/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.light
+++ b/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.light
@@ -464,7 +464,7 @@ reviews:
     # --- level 1: cheap reviewers (run first, in parallel) ---
 
     - slug: repo-rules
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --optional rules --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 

--- a/src/domain.operations/behavior/init/templates/5.1.execution.from_vision.guard
+++ b/src/domain.operations/behavior/init/templates/5.1.execution.from_vision.guard
@@ -156,7 +156,7 @@ reviews:
     # --- level 1: cheap reviewers (run first, in parallel) ---
 
     - slug: repo-rules
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --optional rules --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 

--- a/src/domain.operations/behavior/init/templates/5.1.execution.phase0_to_phaseN.guard
+++ b/src/domain.operations/behavior/init/templates/5.1.execution.phase0_to_phaseN.guard
@@ -160,7 +160,7 @@ reviews:
     # --- level 1: cheap reviewers (run first, in parallel) ---
 
     - slug: repo-rules
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --optional rules --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 

--- a/src/domain.operations/behavior/init/templates/5.3.verification.guard
+++ b/src/domain.operations/behavior/init/templates/5.3.verification.guard
@@ -230,7 +230,7 @@ reviews:
     # --- level 1: cheap reviewers (run first, in parallel) ---
 
     - slug: repo-rules
-      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --optional rules --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
       budget: 3
       level: 1
 


### PR DESCRIPTION
fix(guards): pass --optional rules to repo-rules reviewers (bhrain 0.30.4+)

- add --optional rules to every repo-rules reviewer across all 5 guard
  templates (blueprint light/heavy, execution from_vision/phase0_to_phaseN,
  verification) so an empty-by-design repo-local ruleset skips (0/0 -> approved)
  instead of a false-block that demands a human overrule
- bump rhachet-roles-bhrain peerDependency >=0.12.1 -> >=0.30.4 and devDependency
  0.30.1 -> 0.31.0 so the --optional flag is available where guards consume it
- add [t11] acceptance coverage that reads all source guard templates and locks
  in --optional rules across every variant (contract-snapshot-exhaustiveness)

resolves ehmpathy/rhachet-roles-bhuild#279
ref: ehmpathy/rhachet-roles-bhrain#325

---
🐢🌊 surfed in by seaturtle[bot]