### PR TITLE
fix(init): stamp behavior guard templates with self-referential provenance.uri

### DIFF
--- a/src/domain.operations/behavior/init/initBehaviorDir.integration.test.ts
+++ b/src/domain.operations/behavior/init/initBehaviorDir.integration.test.ts
@@ -590,5 +590,65 @@ describe('initBehaviorDir.integration', () => {
         expect(guardContent).toContain('rationale');
       });
     });
+
+    given('[case5] guards carry self-referential provenance', () => {
+      const templatesUriBase =
+        'node_modules/rhachet-roles-bhuild/dist/domain.operations/behavior/init/templates';
+
+      when('[t0] inited with guard=heavy', () => {
+        then('variant guard uri points at its .heavy source template', () => {
+          initBehaviorDir({
+            behaviorDir,
+            behaviorDirRel: '.behavior/v2025_01_01.test-feature',
+            guard: 'heavy',
+          });
+
+          // the route guard drops the .heavy suffix, but its provenance uri
+          // must point back at the .heavy source so upgrade re-reads the same file
+          const visionGuard = fs.readFileSync(
+            path.join(behaviorDir, '1.vision.guard'),
+            'utf-8',
+          );
+          expect(visionGuard).toContain('provenance:');
+          expect(visionGuard).toContain(
+            `uri: ${templatesUriBase}/1.vision.guard.heavy`,
+          );
+        });
+      });
+
+      when('[t1] inited with guard=light (default)', () => {
+        then('variant guard uri points at its .light source template', () => {
+          initBehaviorDir({
+            behaviorDir,
+            behaviorDirRel: '.behavior/v2025_01_01.test-feature',
+          });
+
+          const blueprintGuard = fs.readFileSync(
+            path.join(behaviorDir, '3.3.1.blueprint.product.guard'),
+            'utf-8',
+          );
+          expect(blueprintGuard).toContain('provenance:');
+          expect(blueprintGuard).toContain(
+            `uri: ${templatesUriBase}/3.3.1.blueprint.product.guard.light`,
+          );
+        });
+
+        then('non-variant guard uri points at its own source template', () => {
+          initBehaviorDir({
+            behaviorDir,
+            behaviorDirRel: '.behavior/v2025_01_01.test-feature',
+          });
+
+          const evaluationGuard = fs.readFileSync(
+            path.join(behaviorDir, '5.2.evaluation.guard'),
+            'utf-8',
+          );
+          expect(evaluationGuard).toContain('provenance:');
+          expect(evaluationGuard).toContain(
+            `uri: ${templatesUriBase}/5.2.evaluation.guard`,
+          );
+        });
+      });
+    });
   });
 });

--- a/src/domain.operations/behavior/init/templates/1.vision.guard.heavy
+++ b/src/domain.operations/behavior/init/templates/1.vision.guard.heavy
@@ -1,3 +1,7 @@
+# provenance = self-referential source template; enables `rhx route.guard.upgrade` idempotency
+provenance:
+  uri: node_modules/rhachet-roles-bhuild/dist/domain.operations/behavior/init/templates/1.vision.guard.heavy
+
 # guard for vision stone
 #
 # requires human approval before stone can be marked as passed

--- a/src/domain.operations/behavior/init/templates/1.vision.guard.light
+++ b/src/domain.operations/behavior/init/templates/1.vision.guard.light
@@ -1,3 +1,7 @@
+# provenance = self-referential source template; enables `rhx route.guard.upgrade` idempotency
+provenance:
+  uri: node_modules/rhachet-roles-bhuild/dist/domain.operations/behavior/init/templates/1.vision.guard.light
+
 # guard for vision stone
 #
 # requires human approval before stone can be marked as passed

--- a/src/domain.operations/behavior/init/templates/2.1.criteria.blackbox.guard.heavy
+++ b/src/domain.operations/behavior/init/templates/2.1.criteria.blackbox.guard.heavy
@@ -1,3 +1,7 @@
+# provenance = self-referential source template; enables `rhx route.guard.upgrade` idempotency
+provenance:
+  uri: node_modules/rhachet-roles-bhuild/dist/domain.operations/behavior/init/templates/2.1.criteria.blackbox.guard.heavy
+
 # guard for criteria stone
 #
 # self-review prompts to ensure criteria quality

--- a/src/domain.operations/behavior/init/templates/3.2.distill.domain._.guard
+++ b/src/domain.operations/behavior/init/templates/3.2.distill.domain._.guard
@@ -1,3 +1,7 @@
+# provenance = self-referential source template; enables `rhx route.guard.upgrade` idempotency
+provenance:
+  uri: node_modules/rhachet-roles-bhuild/dist/domain.operations/behavior/init/templates/3.2.distill.domain._.guard
+
 reviews:
   self:
     - slug: has-ubiquitous-language

--- a/src/domain.operations/behavior/init/templates/3.2.distill.repros.experience._.guard
+++ b/src/domain.operations/behavior/init/templates/3.2.distill.repros.experience._.guard
@@ -1,3 +1,7 @@
+# provenance = self-referential source template; enables `rhx route.guard.upgrade` idempotency
+provenance:
+  uri: node_modules/rhachet-roles-bhuild/dist/domain.operations/behavior/init/templates/3.2.distill.repros.experience._.guard
+
 reviews:
   self:
     - slug: has-critical-paths-identified

--- a/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.heavy
+++ b/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.heavy
@@ -1,3 +1,7 @@
+# provenance = self-referential source template; enables `rhx route.guard.upgrade` idempotency
+provenance:
+  uri: node_modules/rhachet-roles-bhuild/dist/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.heavy
+
 # guard for blueprint stone
 # includes standardized self-review frame + human approval
 

--- a/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.light
+++ b/src/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.light
@@ -1,3 +1,7 @@
+# provenance = self-referential source template; enables `rhx route.guard.upgrade` idempotency
+provenance:
+  uri: node_modules/rhachet-roles-bhuild/dist/domain.operations/behavior/init/templates/3.3.1.blueprint.product.guard.light
+
 # guard for blueprint stone
 # includes standardized self-review frame + human approval
 

--- a/src/domain.operations/behavior/init/templates/5.1.execution.from_vision.guard
+++ b/src/domain.operations/behavior/init/templates/5.1.execution.from_vision.guard
@@ -1,3 +1,7 @@
+# provenance = self-referential source template; enables `rhx route.guard.upgrade` idempotency
+provenance:
+  uri: node_modules/rhachet-roles-bhuild/dist/domain.operations/behavior/init/templates/5.1.execution.from_vision.guard
+
 # guard for execution stone (from vision - nano size)
 # includes standardized self-review frame
 

--- a/src/domain.operations/behavior/init/templates/5.1.execution.phase0_to_phaseN.guard
+++ b/src/domain.operations/behavior/init/templates/5.1.execution.phase0_to_phaseN.guard
@@ -1,3 +1,7 @@
+# provenance = self-referential source template; enables `rhx route.guard.upgrade` idempotency
+provenance:
+  uri: node_modules/rhachet-roles-bhuild/dist/domain.operations/behavior/init/templates/5.1.execution.phase0_to_phaseN.guard
+
 # guard for execution stone
 # includes standardized self-review frame
 

--- a/src/domain.operations/behavior/init/templates/5.2.evaluation.guard
+++ b/src/domain.operations/behavior/init/templates/5.2.evaluation.guard
@@ -1,3 +1,7 @@
+# provenance = self-referential source template; enables `rhx route.guard.upgrade` idempotency
+provenance:
+  uri: node_modules/rhachet-roles-bhuild/dist/domain.operations/behavior/init/templates/5.2.evaluation.guard
+
 reviews:
   self:
     - slug: has-complete-implementation-record

--- a/src/domain.operations/behavior/init/templates/5.3.verification.guard
+++ b/src/domain.operations/behavior/init/templates/5.3.verification.guard
@@ -1,3 +1,7 @@
+# provenance = self-referential source template; enables `rhx route.guard.upgrade` idempotency
+provenance:
+  uri: node_modules/rhachet-roles-bhuild/dist/domain.operations/behavior/init/templates/5.3.verification.guard
+
 artifacts:
   # track verification progress
   - "$route/5.3.verification.yield.md"

--- a/src/domain.operations/behavior/init/templates/5.5.playtest.guard
+++ b/src/domain.operations/behavior/init/templates/5.5.playtest.guard
@@ -1,3 +1,7 @@
+# provenance = self-referential source template; enables `rhx route.guard.upgrade` idempotency
+provenance:
+  uri: node_modules/rhachet-roles-bhuild/dist/domain.operations/behavior/init/templates/5.5.playtest.guard
+
 artifacts:
   # track playtest progress
   - "$route/5.5.playtest.yield.md"


### PR DESCRIPTION
fix(init): stamp behavior guard templates with self-referential provenance.uri

- add a provenance block to every *.guard* template under
  behavior/init/templates, whose uri points at its own installed dist path
- variant guards (.heavy/.light) point at their suffixed source file, since
  route.guard.upgrade re-reads that exact template after the suffix is stripped
- lets bhuild init -> route.guard.upgrade round-trip stay idempotent: the
  provenance block survives, so upgrades report kept (or upgrade on a real bump)
  instead of skipped
- adopt rhachet-roles-bhrain 0.31.0 (ships route.guard.upgrade) + wire its route
  statusline
- cover the stamping with integration tests: variant guards keep their suffix in
  the uri, non-variant guards point at their own template

---
🐢🌊 surfed in by seaturtle[bot]